### PR TITLE
Update benchmark base images and package versions

### DIFF
--- a/images/discovery/Dockerfile
+++ b/images/discovery/Dockerfile
@@ -1,6 +1,10 @@
-FROM debian:bullseye-slim
+#####
+# Dockerfile for service readiness discovery
+#####
+
+FROM debian:bookworm-slim
 
 
 RUN apt-get update && \
-    apt-get install -y iproute2 netcat && \
+    apt-get install -y iproute2 netcat-openbsd && \
     rm -rf /var/lib/apt/lists/*

--- a/images/fio/Dockerfile
+++ b/images/fio/Dockerfile
@@ -1,11 +1,13 @@
-ARG FEDORA_VERSION=37
-FROM fedora:${FEDORA_VERSION}
+#####
+# Dockerfile for the fio benchmarks
+#####
 
-ARG FIO_VERSION=3.30-2
-ARG FEDORA_VERSION
-RUN dnf install -y tini fio-${FIO_VERSION}.fc${FEDORA_VERSION} && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+FROM debian:bookworm-slim
+
+ARG FIO_VERSION=3.33-3
+RUN apt-get update && \
+    apt-get install -y tini fio=${FIO_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["tini", "-g", "--"]
 # Install the setup and run scripts

--- a/images/iperf/Dockerfile
+++ b/images/iperf/Dockerfile
@@ -2,9 +2,10 @@
 # Dockerfile for the iperf benchmarks
 #####
 
-FROM debian:latest
 
-ARG IPERF_VERSION=2.0.14a+dfsg1-1
+FROM debian:bookworm-slim
+
+ARG IPERF_VERSION=2.1.8+dfsg-1
 RUN apt-get update && \
     apt-get install -y "iperf=$IPERF_VERSION" && \
     rm -rf /var/lib/apt/lists/*

--- a/images/mpi-benchmarks/Dockerfile
+++ b/images/mpi-benchmarks/Dockerfile
@@ -3,7 +3,7 @@
 # https://www.intel.com/content/www/us/en/develop/documentation/imb-user-guide/top.html
 #####
 
-FROM rockylinux:8.6
+FROM rockylinux:9.2
 
 ARG MPITESTS_VERSION=5.8
 RUN yum install -y \

--- a/images/perftest/Dockerfile
+++ b/images/perftest/Dockerfile
@@ -2,9 +2,9 @@
 # Dockerfile for the RDMA bandwidth and latency benchmarks
 #####
 
-FROM rockylinux:8.6
+FROM rockylinux:9.2
 
-ARG PERFTEST_VERSION=4.5
+ARG PERFTEST_VERSION=4.5.0.20
 RUN yum install -y "perftest-${PERFTEST_VERSION}" && \
     yum clean all -y && \
     rm -rf /var/cache


### PR DESCRIPTION
Swap to Rocky Linux 9.2 or Debian Bookworm as much as possible for consistency. Update package versions to match those base images.