### PR TITLE
Fix openfoam solverInfo error

### DIFF
--- a/images/openfoam/scripts/openfoam-init
+++ b/images/openfoam/scripts/openfoam-init
@@ -14,6 +14,7 @@ cp -r /opt/hpc/Lid_driven_cavity-3d/${PROBLEM_SIZE}/* /opt/benchmark
 ln -sf /opt/benchmark/system/fvSolution.${ITERATIVE_METHOD} /opt/benchmark/system/fvSolution
 mv /opt/benchmark/constant/transportProperties /opt/benchmark/constant/physicalProperties
 sed -i "s/^numberOfSubdomains.*/numberOfSubdomains ${NUM_PROCS};/g" /opt/benchmark/system/decomposeParDict
+sed -i "s/\(#includeFunc  solverInfo\)/\/\/ \1/" /opt/benchmark/system/controlDict # comment out solverInfo
 
 # Stage benchmark datafiles
 cd /opt/benchmark


### PR DESCRIPTION
Pre-PR fails with error:

```
--> FOAM FATAL IO ERROR: 
Cannot find functionObject configuration file solverInfo
```

Cannot see what's changed here, but from [the docs](https://www.openfoam.com/documentation/guides/latest/doc/guide-fos-utilities-solverinfo.html) it only affects informational output:
> The solverInfo function object reports the solver performance information for a list of fields

hence this PR just comments-out the include for it.

From the docs this config object used to be called `residuals`; the benchmark already has that commented-out.

