### PR TITLE
Update ClusterRole to include 'pytorchs' API resource

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -26,6 +26,7 @@ rules:
       - rdmabandwidths.perftest.stackhpc.com
       - rdmalatencies.perftest.stackhpc.com
       - fios.perftest.stackhpc.com
+      - pytorchs.perftest.stackhpc.com
     verbs:
       - update
       - patch


### PR DESCRIPTION
Deploying this as per the docs currently fails with the controller crashing:

```
easykube.kubernetes.client.errors.ApiError: customresourcedefinitions.apiextensions.k8s.io "pytorchs.perftest.stackhpc.com" is forbidden: User "system:serviceaccount:default:kube-perftest-operator" ca
nnot patch resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

This PR updates the template to include the new `pytorchs` resource as introduced in #13 