### PR TITLE
Fix azimuth-cloud actions org

### DIFF
--- a/.github/workflows/publish-benchmark-images.yaml
+++ b/.github/workflows/publish-benchmark-images.yaml
@@ -52,7 +52,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: stackhpc/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: ${{ matrix.component }}
           context: ./images/${{ matrix.component }}

--- a/.github/workflows/publish-operator.yaml
+++ b/.github/workflows/publish-operator.yaml
@@ -40,7 +40,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push image
-        uses: stackhpc/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
         with:
           cache-key: kube-perftest-controller
           context: ./python
@@ -64,10 +64,10 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: stackhpc/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@master
 
       - name: Publish Helm charts
-        uses: stackhpc/github-actions/helm-publish@master
+        uses: azimuth-cloud/github-actions/helm-publish@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.semver.outputs.version }}


### PR DESCRIPTION
stackhpc/github-actions was migrated to azimuth-cloud. Fix this so it doens't confuse pinning actions.